### PR TITLE
Do not pass kw mem and cpu if not set

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -205,3 +205,11 @@ class FunctionConfig(BaseModel):
     @property
     def unpacked_secrets(self) -> Optional[Dict]:
         return decode_and_parse(self.secret)
+
+    def get_memory_and_cpu(self):
+        kw = {}
+        if self.memory is not None:
+            kw["memory"] = self.memory
+        if self.cpu is not None:
+            kw["cpu"] = self.cpu
+        return kw

--- a/src/function.py
+++ b/src/function.py
@@ -93,8 +93,7 @@ def create_function_and_wait(client: CogniteClient, file_id: int, config: Functi
         api_key=config.tenant.runtime_key,
         function_path=config.file,
         secrets=secrets,
-        memory=config.memory,
-        cpu=config.cpu,
+        **config.get_memory_and_cpu(),  # Do not pass kwargs if mem/cpu is not set
     )
     logging.info(f"Function '{external_id}' created. Waiting for deployment...")
     function = await_function_deployment(client, external_id, config.deploy_wait_time_sec)


### PR DESCRIPTION
The experimental client defines these as default values in the function definition. Thus, we cannot send them as kwargs when they are unset (`None`):

<img width="733" alt="Screenshot 2021-02-15 at 18 27 18" src="https://user-images.githubusercontent.com/8521241/107977497-8112ea00-6fbb-11eb-8d13-e498737b1c9c.png">
