### PR TITLE
Make code more robust for FilesAPI bad consistency...

### DIFF
--- a/src/function.py
+++ b/src/function.py
@@ -140,7 +140,11 @@ def zip_and_upload_folder(client: CogniteClient, config: FunctionConfig, name: s
         data_set_id = get_data_set_id_from_external_id(client, config.data_set_external_id)
 
     file_meta = client.files.upload_bytes(
-        buf.getvalue(), name=name, external_id=name, data_set_id=data_set_id, overwrite=True,
+        buf.getvalue(),
+        name=name,
+        external_id=name,
+        data_set_id=data_set_id,
+        overwrite=True,
     )
     if file_meta.id is not None:
         logger.info(f"File upload successful ({name})!")


### PR DESCRIPTION
Jørgen and Sara from Ringerikskraft keep running into duplication errors from the API, like this one: (which looks like a consistency error for the `FilesAPI` to me):
```
Warning: schedule: Deleted all (6) existing schedule(s)!
Warning: function: Found existing function 'people_detector-master'. Deleting ...
Warning: function: Delete of function 'people_detector-master' successful!
Warning: function: Found existing file people_detector-master.zip. Deleting ...
Warning: function: Did delete file people_detector-master.zip.
Warning: function: Uploading code from 'people_detector' to 'people_detector-master.zip'
Warning: function: Added common directory: 'common' to the function
Warning: function: Upload successful!
Warning: function: Trying to create function 'people_detector-master'...
Warning: function: No extra secrets added to function 'people_detector-master'
Warning: root: Function 'people_detector-master' created. Waiting for deployment...
Warning: function: Found existing file people_detector-master.zip. Deleting ...
Warning: function: Did delete file people_detector-master.zip.
Warning: retry.api: Function people_detector-master did not deploy within 1200 seconds., retrying in 2 seconds...
Warning: function: Uploading code from 'people_detector' to 'people_detector-master.zip'
Warning: function: Added common directory: 'common' to the function
Warning: function: Upload successful!
Warning: function: Trying to create function 'people_detector-master'...
Warning: function: No extra secrets added to function 'people_detector-master'
Warning: schedule: No existing schedule(s) to delete!
Warning: function: Found existing function 'people_detector-master'. Deleting ...
Warning: function: Delete of function 'people_detector-master' successful!
Warning: retry.api: Function externalId duplicated, retrying in 4 seconds...
Warning: function: Uploading code from 'people_detector' to 'people_detector-master.zip'
Warning: function: Added common directory: 'common' to the function
Traceback (most recent call last):
  File "/app/index.py", line 61, in <module>
    main(config)
  File "/app/index.py", line 26, in main
    function = upload_and_create(client, config)
  File "<decorator-gen-2>", line 2, in upload_and_create
  File "/app/retry/api.py", line 74, in retry_decorator
    logger)
  File "/app/retry/api.py", line 33, in __retry_internal
    return f()
  File "/app/function.py", line 155, in upload_and_create
    file_id = zip_and_upload_folder(client, config, zip_file_name)
  File "/app/function.py", line 139, in zip_and_upload_folder
    file_meta = client.files.upload_bytes(buf.getvalue(), name=name, external_id=name, data_set_id=data_set_id)
  File "/app/cognite/client/_api/files.py", line 663, in upload_bytes
    url_path=self._RESOURCE_PATH, json=file_metadata.dump(camel_case=True), params={"overwrite": overwrite}
  File "/app/cognite/client/_api_client.py", line 114, in _post
    "POST", url_path, json=json, headers=headers, params=params, timeout=self._config.timeout
  File "/app/cognite/client/_api_client.py", line 151, in _do_request
    self._raise_API_error(res, payload=json_payload)
  File "/app/cognite/client/_api_client.py", line 741, in _raise_API_error
    raise CogniteAPIError(msg, code, x_request_id, missing=missing, duplicated=duplicated, extra=extra)
cognite.client.exceptions.CogniteAPIError: Duplicate external ids: people_detector-master.zip | code: 409 | X-Request-ID: 88b011c9-bc4f-99cc-b95b-8ef44abe3b41
Duplicated: [{'externalId': 'people_detector-master.zip'}]
```