### PR TITLE
Remove scheule delete from schedule deploy fn

### DIFF
--- a/src/schedule.py
+++ b/src/schedule.py
@@ -28,7 +28,7 @@ def deploy_schedule(client: CogniteClient, function: Function, config: FunctionC
         logger.info("No schedules to attach!")
         return
 
-    logger.info(f"Attaching {len(config.schedules)} to {function.external_id}")
+    logger.info(f"Attaching {len(config.schedules)} schedule(s) to {function.external_id}")
     for schedule in config.schedules:
         client.functions.schedules.create(
             function_external_id=function.external_id,

--- a/src/schedule.py
+++ b/src/schedule.py
@@ -24,12 +24,11 @@ def delete_all_schedules_for_ext_id(client: CogniteClient, function_external_id:
 
 
 def deploy_schedule(client: CogniteClient, function: Function, config: FunctionConfig):
-    delete_all_schedules_for_ext_id(client, function.external_id)
-
     if not config.schedules:
-        logger.info("Skipped step of attaching schedules!")
+        logger.info("No schedules to attach!")
         return
 
+    logger.info(f"Attaching {len(config.schedules)} to {function.external_id}")
     for schedule in config.schedules:
         client.functions.schedules.create(
             function_external_id=function.external_id,
@@ -37,4 +36,4 @@ def deploy_schedule(client: CogniteClient, function: Function, config: FunctionC
             name=schedule.name,
             data=schedule.data,
         )
-        logger.info(f"Successfully deployed schedule {schedule.name} with cron expression {schedule.cron}.")
+        logger.info(f"- Schedule '{schedule.name}' with cron: '{schedule.cron}' deployed successfully!")

--- a/src/schedule.py
+++ b/src/schedule.py
@@ -36,4 +36,4 @@ def deploy_schedule(client: CogniteClient, function: Function, config: FunctionC
             name=schedule.name,
             data=schedule.data,
         )
-        logger.info(f"- Schedule '{schedule.name}' with cron: '{schedule.cron}' deployed successfully!")
+        logger.info(f"- Schedule '{schedule.name}' with cron: '{schedule.cron}' attached successfully!")

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,25 +1,14 @@
 from unittest.mock import MagicMock, call
 
-from cognite.experimental.data_classes.functions import FunctionSchedule
-
 from schedule import deploy_schedule
 
 
 def test_deploy_schedule(cognite_experimental_client_mock, valid_config):
-    schedules = [
-        FunctionSchedule(id=1, name=valid_config.schedules[0].name, function_external_id=valid_config.external_id),
-        FunctionSchedule(id=2, name="random schedule", function_external_id=valid_config.external_id),
-    ]
-
-    cognite_experimental_client_mock.functions.schedules.list.return_value = schedules
-
     function_mock = MagicMock()
-    function_mock.list_schedules.return_value = schedules
     function_mock.external_id = valid_config.external_id
 
     deploy_schedule(cognite_experimental_client_mock, function_mock, valid_config)
 
-    assert cognite_experimental_client_mock.functions.schedules.delete.call_args_list == [call(1), call(2)]
     assert cognite_experimental_client_mock.functions.schedules.create.call_args_list == [
         call(
             function_external_id=valid_config.external_id,


### PR DESCRIPTION
+ improve logging, before:
```
Warning: schedule: Deleted all (1) existing schedule(s)!
(...)
Warning: function: Function deployment successful! Deployment took 176.48 seconds
Warning: __main__: Successfully created and deployed function example_function1-master with id 8101158008689270
Warning: schedule: No existing schedule(s) to delete!
Warning: schedule: Successfully deployed schedule example_function1-master:My daily schedule with cron expression 0 0 * * *.
```
Now:
```
Warning: schedule: Deleted all (1) existing schedule(s)!
(...)
Warning: function: Function deployment successful! Deployment took 164.39 seconds
Warning: __main__: Successfully created and deployed function example_function1-master with id 6140110941155372
Warning: schedule: Attaching 1 to example_function1-master
Warning: schedule: - Schedule 'example_function1-master:My daily schedule' with cron: '0 0 * * *' attached successfully!