### PR TITLE
Use PY38 and add handle function check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-# gcr.io/distroless/python3-debian10 (runtime env is using 3.7 and that's important for native dependencies)
-FROM python:3.7-slim AS builder
+FROM python:3.8-slim AS builder
 
 ADD src /app
 WORKDIR /
 
-# Poetry setup
 RUN pip3 install poetry
 RUN poetry config virtualenvs.create false
 
@@ -12,15 +10,13 @@ COPY action.yaml /app
 COPY poetry.lock .
 COPY pyproject.toml .
 
-# by default poetry does NOT export dev dependencies here
+# By default poetry does NOT export dev dependencies here
 RUN poetry export -f requirements.txt --output /requirements.txt
 
 # We are installing a dependency here directly into our app source dir
 RUN pip3 install --target=/app -r /requirements.txt --upgrade
 
-# A distroless container image with Python and some basics like SSL certificates
-# https://github.com/GoogleContainerTools/distroless
-FROM gcr.io/distroless/python3-debian10
+FROM python:3.8-buster
 COPY --from=builder /app /app
 ENV PYTHONPATH /app
-CMD ["/app/index.py"]
+CMD ["python", "/app/index.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY poetry.lock .
 COPY pyproject.toml .
 
 # By default poetry does NOT export dev dependencies here
-RUN poetry export -f requirements.txt --output /requirements.txt
+RUN poetry export -f requirements.txt --output /requirements.txt --without-hashes
 
 # We are installing a dependency here directly into our app source dir
 RUN pip3 install --target=/app -r /requirements.txt --upgrade

--- a/poetry.lock
+++ b/poetry.lock
@@ -91,11 +91,10 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "cognite-sdk"
-version = "2.19.0"
+version = "2.20.0"
 description = "Client library for Cognite Data Fusion (CDF)"
 category = "main"
 optional = false
@@ -162,15 +161,25 @@ smmap = ">=3.0.1,<5"
 
 [[package]]
 name = "gitpython"
-version = "3.1.17"
+version = "3.1.18"
 description = "Python Git Library"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
-typing-extensions = {version = ">=3.7.4.0", markers = "python_version < \"3.8\""}
+
+[[package]]
+name = "humanize"
+version = "3.9.0"
+description = "Python humanize utilities"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+tests = ["freezegun", "pytest", "pytest-cov"]
 
 [[package]]
 name = "idna"
@@ -179,22 +188,6 @@ description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
-name = "importlib-metadata"
-version = "4.5.0"
-description = "Read metadata from Python packages"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
-zipp = ">=0.5"
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "iniconfig"
@@ -333,9 +326,6 @@ category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-
 [package.extras]
 dev = ["pre-commit", "tox"]
 
@@ -382,7 +372,6 @@ python-versions = ">=3.5"
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=17.4.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 more-itertools = ">=4.0.0"
 packaging = "*"
@@ -546,7 +535,6 @@ optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-importlib-metadata = {version = ">=1.7.0", markers = "python_version < \"3.8\""}
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 
 [[package]]
@@ -597,22 +585,10 @@ brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
-[[package]]
-name = "zipp"
-version = "3.4.1"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
-
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.7"
-content-hash = "a46424401d7dc7714d7b7c507e80b70000b3b2eafd35557a56a67bdbc72ba9b6"
+python-versions = "^3.8"
+content-hash = "bc13bd5ce2e1f9940ef6dbc71ee182e061acaec43c27a4811861ee777d5faeda"
 
 [metadata.files]
 appdirs = [
@@ -647,8 +623,8 @@ click = [
     {file = "click-8.0.1.tar.gz", hash = "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a"},
 ]
 cognite-sdk = [
-    {file = "cognite-sdk-2.19.0.tar.gz", hash = "sha256:a32c671aac815e40c1e32b2dea9ed9a226ce730c26183629c8ef83020cd43c27"},
-    {file = "cognite_sdk-2.19.0-py3-none-any.whl", hash = "sha256:f9c468edbcf424538253bb35bac4aced9e4a193f71c85f825d0ec1eddf403e63"},
+    {file = "cognite-sdk-2.20.0.tar.gz", hash = "sha256:8e26fd1c3790503743aba60ff2de02b3f34e516c5883ac12a84b6d6e76295c0d"},
+    {file = "cognite_sdk-2.20.0-py3-none-any.whl", hash = "sha256:9ce4e22ef8a1d480d5a8e26d81ae6955a0338a6e846396b8888b6828587111ea"},
 ]
 cognite-sdk-experimental = [
     {file = "cognite-sdk-experimental-0.54.0.tar.gz", hash = "sha256:c9286488d6efc2a78988ec6f99a6e80fe9bb67b2bb673f5ad53e54ff889af91d"},
@@ -720,16 +696,16 @@ gitdb = [
     {file = "gitdb-4.0.7.tar.gz", hash = "sha256:96bf5c08b157a666fec41129e6d327235284cca4c81e92109260f353ba138005"},
 ]
 gitpython = [
-    {file = "GitPython-3.1.17-py3-none-any.whl", hash = "sha256:29fe82050709760081f588dd50ce83504feddbebdc4da6956d02351552b1c135"},
-    {file = "GitPython-3.1.17.tar.gz", hash = "sha256:ee24bdc93dce357630764db659edaf6b8d664d4ff5447ccfeedd2dc5c253f41e"},
+    {file = "GitPython-3.1.18-py3-none-any.whl", hash = "sha256:fce760879cd2aebd2991b3542876dc5c4a909b30c9d69dfc488e504a8db37ee8"},
+    {file = "GitPython-3.1.18.tar.gz", hash = "sha256:b838a895977b45ab6f0cc926a9045c8d1c44e2b653c1fcc39fe91f42c6e8f05b"},
+]
+humanize = [
+    {file = "humanize-3.9.0-py3-none-any.whl", hash = "sha256:2cc4f7d2f5994ea9fcddd4b681ddea9abd23baa8cc64bd0af041a0162636f31c"},
+    {file = "humanize-3.9.0.tar.gz", hash = "sha256:892a5b7b87763c4c6997a58382c2b1f4614048a2e01c23ef1bb0456e6f9d4d5d"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
-]
-importlib-metadata = [
-    {file = "importlib_metadata-4.5.0-py3-none-any.whl", hash = "sha256:833b26fb89d5de469b24a390e9df088d4e52e4ba33b01dc5e0e4f41b81a16c00"},
-    {file = "importlib_metadata-4.5.0.tar.gz", hash = "sha256:b142cc1dd1342f31ff04bb7d022492b09920cb64fed867cd3ea6f80fe3ebd139"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
@@ -1032,8 +1008,4 @@ typing-extensions = [
 urllib3 = [
     {file = "urllib3-1.26.5-py2.py3-none-any.whl", hash = "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c"},
     {file = "urllib3-1.26.5.tar.gz", hash = "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"},
-]
-zipp = [
-    {file = "zipp-3.4.1-py3-none-any.whl", hash = "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"},
-    {file = "zipp-3.4.1.tar.gz", hash = "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -288,19 +288,19 @@ pyparsing = ">=2.0.2"
 
 [[package]]
 name = "pandas"
-version = "1.1.5"
+version = "1.2.4"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = false
-python-versions = ">=3.6.1"
+python-versions = ">=3.7.1"
 
 [package.dependencies]
-numpy = ">=1.15.4"
+numpy = ">=1.16.5"
 python-dateutil = ">=2.7.3"
-pytz = ">=2017.2"
+pytz = ">=2017.3"
 
 [package.extras]
-test = ["pytest (>=4.0.2)", "pytest-xdist", "hypothesis (>=3.58)"]
+test = ["pytest (>=5.0.1)", "pytest-xdist", "hypothesis (>=3.58)"]
 
 [[package]]
 name = "pathspec"
@@ -588,7 +588,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "bc13bd5ce2e1f9940ef6dbc71ee182e061acaec43c27a4811861ee777d5faeda"
+content-hash = "66da9fe95ff9ed93ab2b89c1d404c06013de94df32d0a7f3a20b4382ae7ce1d8"
 
 [metadata.files]
 appdirs = [
@@ -777,30 +777,22 @@ packaging = [
     {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
 ]
 pandas = [
-    {file = "pandas-1.1.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:bf23a3b54d128b50f4f9d4675b3c1857a688cc6731a32f931837d72effb2698d"},
-    {file = "pandas-1.1.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5a780260afc88268a9d3ac3511d8f494fdcf637eece62fb9eb656a63d53eb7ca"},
-    {file = "pandas-1.1.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:b61080750d19a0122469ab59b087380721d6b72a4e7d962e4d7e63e0c4504814"},
-    {file = "pandas-1.1.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:0de3ddb414d30798cbf56e642d82cac30a80223ad6fe484d66c0ce01a84d6f2f"},
-    {file = "pandas-1.1.5-cp36-cp36m-win32.whl", hash = "sha256:70865f96bb38fec46f7ebd66d4b5cfd0aa6b842073f298d621385ae3898d28b5"},
-    {file = "pandas-1.1.5-cp36-cp36m-win_amd64.whl", hash = "sha256:19a2148a1d02791352e9fa637899a78e371a3516ac6da5c4edc718f60cbae648"},
-    {file = "pandas-1.1.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:26fa92d3ac743a149a31b21d6f4337b0594b6302ea5575b37af9ca9611e8981a"},
-    {file = "pandas-1.1.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c16d59c15d946111d2716856dd5479221c9e4f2f5c7bc2d617f39d870031e086"},
-    {file = "pandas-1.1.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3be7a7a0ca71a2640e81d9276f526bca63505850add10206d0da2e8a0a325dae"},
-    {file = "pandas-1.1.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:573fba5b05bf2c69271a32e52399c8de599e4a15ab7cec47d3b9c904125ab788"},
-    {file = "pandas-1.1.5-cp37-cp37m-win32.whl", hash = "sha256:21b5a2b033380adbdd36b3116faaf9a4663e375325831dac1b519a44f9e439bb"},
-    {file = "pandas-1.1.5-cp37-cp37m-win_amd64.whl", hash = "sha256:24c7f8d4aee71bfa6401faeba367dd654f696a77151a8a28bc2013f7ced4af98"},
-    {file = "pandas-1.1.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2860a97cbb25444ffc0088b457da0a79dc79f9c601238a3e0644312fcc14bf11"},
-    {file = "pandas-1.1.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5008374ebb990dad9ed48b0f5d0038124c73748f5384cc8c46904dace27082d9"},
-    {file = "pandas-1.1.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2c2f7c670ea4e60318e4b7e474d56447cf0c7d83b3c2a5405a0dbb2600b9c48e"},
-    {file = "pandas-1.1.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:0a643bae4283a37732ddfcecab3f62dd082996021b980f580903f4e8e01b3c5b"},
-    {file = "pandas-1.1.5-cp38-cp38-win32.whl", hash = "sha256:5447ea7af4005b0daf695a316a423b96374c9c73ffbd4533209c5ddc369e644b"},
-    {file = "pandas-1.1.5-cp38-cp38-win_amd64.whl", hash = "sha256:4c62e94d5d49db116bef1bd5c2486723a292d79409fc9abd51adf9e05329101d"},
-    {file = "pandas-1.1.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:731568be71fba1e13cae212c362f3d2ca8932e83cb1b85e3f1b4dd77d019254a"},
-    {file = "pandas-1.1.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c61c043aafb69329d0f961b19faa30b1dab709dd34c9388143fc55680059e55a"},
-    {file = "pandas-1.1.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2b1c6cd28a0dfda75c7b5957363333f01d370936e4c6276b7b8e696dd500582a"},
-    {file = "pandas-1.1.5-cp39-cp39-win32.whl", hash = "sha256:c94ff2780a1fd89f190390130d6d36173ca59fcfb3fe0ff596f9a56518191ccb"},
-    {file = "pandas-1.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:edda9bacc3843dfbeebaf7a701763e68e741b08fccb889c003b0a52f0ee95782"},
-    {file = "pandas-1.1.5.tar.gz", hash = "sha256:f10fc41ee3c75a474d3bdf68d396f10782d013d7f67db99c0efbfd0acb99701b"},
+    {file = "pandas-1.2.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c601c6fdebc729df4438ec1f62275d6136a0dd14d332fc0e8ce3f7d2aadb4dd6"},
+    {file = "pandas-1.2.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:8d4c74177c26aadcfb4fd1de6c1c43c2bf822b3e0fc7a9b409eeaf84b3e92aaa"},
+    {file = "pandas-1.2.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:b730add5267f873b3383c18cac4df2527ac4f0f0eed1c6cf37fcb437e25cf558"},
+    {file = "pandas-1.2.4-cp37-cp37m-win32.whl", hash = "sha256:2cb7e8f4f152f27dc93f30b5c7a98f6c748601ea65da359af734dd0cf3fa733f"},
+    {file = "pandas-1.2.4-cp37-cp37m-win_amd64.whl", hash = "sha256:2111c25e69fa9365ba80bbf4f959400054b2771ac5d041ed19415a8b488dc70a"},
+    {file = "pandas-1.2.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:167693a80abc8eb28051fbd184c1b7afd13ce2c727a5af47b048f1ea3afefff4"},
+    {file = "pandas-1.2.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:612add929bf3ba9d27b436cc8853f5acc337242d6b584203f207e364bb46cb12"},
+    {file = "pandas-1.2.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:971e2a414fce20cc5331fe791153513d076814d30a60cd7348466943e6e909e4"},
+    {file = "pandas-1.2.4-cp38-cp38-win32.whl", hash = "sha256:68d7baa80c74aaacbed597265ca2308f017859123231542ff8a5266d489e1858"},
+    {file = "pandas-1.2.4-cp38-cp38-win_amd64.whl", hash = "sha256:bd659c11a4578af740782288cac141a322057a2e36920016e0fc7b25c5a4b686"},
+    {file = "pandas-1.2.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9db70ffa8b280bb4de83f9739d514cd0735825e79eef3a61d312420b9f16b758"},
+    {file = "pandas-1.2.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:298f0553fd3ba8e002c4070a723a59cdb28eda579f3e243bc2ee397773f5398b"},
+    {file = "pandas-1.2.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:52d2472acbb8a56819a87aafdb8b5b6d2b3386e15c95bde56b281882529a7ded"},
+    {file = "pandas-1.2.4-cp39-cp39-win32.whl", hash = "sha256:d0877407359811f7b853b548a614aacd7dea83b0c0c84620a9a643f180060950"},
+    {file = "pandas-1.2.4-cp39-cp39-win_amd64.whl", hash = "sha256:2b063d41803b6a19703b845609c0b700913593de067b552a8b24dd8eeb8c9895"},
+    {file = "pandas-1.2.4.tar.gz", hash = "sha256:649ecab692fade3cbfcf967ff936496b0cfba0af00a55dfaacd82bdda5cb2279"},
 ]
 pathspec = [
     {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,13 @@ include_trailing_comma=true    # corresponds to -tc flag
 skip_glob = '^((?!py$).)*$'    # this makes sort all Python files
 
 [tool.poetry.dependencies]
-python = "^3.7"
-cognite-sdk = "^2.19"
+python = "^3.8"
 cognite-sdk-experimental = "^0.54"
 pydantic = "^1.8"
 python-crontab = "^2.5"
 PyYAML = "^5.3"
 retry = "^0.9"
+humanize = "^3.9"
 
 [tool.poetry.dev-dependencies]
 bandit = "1.6.2"

--- a/src/checks.py
+++ b/src/checks.py
@@ -1,0 +1,43 @@
+import ast
+import logging
+from pathlib import Path
+
+from config import FunctionConfig
+
+logger = logging.getLogger(__name__)
+
+
+HANDLE_ARGS = ("data", "client", "secrets", "function_call_info")
+
+
+class FunctionValidationError(Exception):
+    pass
+
+
+def run_checks(config: FunctionConfig) -> None:
+    # Python-only checks:
+    if config.function_file.endswith(".py"):
+        _check_handle_args(config.function_folder / config.function_file)
+
+
+def _check_handle_args(file_path: Path, fn_name: str = "handle") -> None:
+    # If missing raises FileNotFoundError, which is a perfectly fine error message
+    with open(file_path) as file:
+        file = file.read()
+
+    for node in ast.walk(ast.parse(file)):
+        if isinstance(node, ast.FunctionDef) and node.name == fn_name:
+            bad_args = set(param.arg for param in node.args.args).difference(HANDLE_ARGS)
+            if not bad_args:
+                logger.info(f"Signature of function entrypoint, '{fn_name}', in file '{file_path}' validated!")
+                return
+            err_msg = (
+                f"In file '{file_path}', function '{fn_name}' contained illegal args: {list(bad_args)}. "
+                f"The function args must be a strict subset of: {list(HANDLE_ARGS)} (ordering is not important)"
+            )
+            logger.error(err_msg)
+            raise FunctionValidationError(err_msg)
+
+    err_msg = f"No function named '{fn_name}' was found in file '{file_path}'. It is required!"
+    logger.error(err_msg)
+    raise FunctionValidationError(err_msg)

--- a/src/function.py
+++ b/src/function.py
@@ -2,9 +2,7 @@ import io
 import logging
 import os
 import time
-from contextlib import contextmanager
 from pathlib import Path
-from typing import Union
 from zipfile import ZipFile
 
 from cognite.client.data_classes import DataSet, FileMetadata
@@ -15,6 +13,7 @@ from retry import retry
 
 from config import DEPLOY_WAIT_TIME_SEC, FunctionConfig
 from schedule import delete_all_schedules_for_ext_id
+from utils import temporary_chdir
 
 logger = logging.getLogger(__name__)
 
@@ -122,16 +121,6 @@ def create_function_and_wait(client: CogniteClient, file_id: int, config: Functi
     )
     logging.info(f"Function '{external_id}' created. Waiting for deployment...")
     return await_function_deployment(client, external_id, DEPLOY_WAIT_TIME_SEC)
-
-
-@contextmanager
-def temporary_chdir(path: Union[str, Path]):
-    old_path = os.getcwd()
-    os.chdir(path)
-    try:
-        yield
-    finally:
-        os.chdir(old_path)
 
 
 def _write_files_to_zip_buffer(zf: ZipFile, directory: Path):

--- a/src/function.py
+++ b/src/function.py
@@ -9,6 +9,7 @@ from cognite.client.data_classes import DataSet, FileMetadata
 from cognite.client.exceptions import CogniteAPIError
 from cognite.experimental import CogniteClient
 from cognite.experimental.data_classes import Function
+from humanize.time import precisedelta
 from retry import retry
 
 from config import DEPLOY_WAIT_TIME_SEC, FunctionConfig
@@ -53,14 +54,14 @@ def await_function_deployment(client: CogniteClient, external_id: str, wait_time
             logger.warning(err)
             raise FunctionDeployError(err)
         elif function.status == "Ready":
-            logger.info(f"Function deployment successful! Deployment took {time.time()-t0:.2f} seconds")
+            logger.info(f"Function deployment successful! Deployment took {precisedelta(time.time()-t0)}")
             return function
         elif function.status == "Failed":
-            logger.warning(f"Deployment failed after {time.time()-t0:.2f} seconds! Error: {function.error['trace']}")
+            logger.warning(f"Deployment failed after {precisedelta(time.time()-t0)}! Error: {function.error['trace']}")
             raise FunctionDeployError(function.error["trace"])
         time.sleep(5)
 
-    err = f"Function {external_id} (ID: {function.id}) did not deploy within {wait_time_sec} seconds."
+    err = f"Function {external_id} (ID: {function.id}) did not deploy within {precisedelta(wait_time_sec)}."
     logger.error(err)
     raise FunctionDeployTimeout(err)
 

--- a/src/index.py
+++ b/src/index.py
@@ -3,6 +3,7 @@ import os
 
 import yaml
 
+from checks import run_checks
 from config import FunctionConfig, TenantConfig, create_experimental_cognite_client
 from function import try_delete, upload_and_create
 from github_log_handler import GitHubLogHandler
@@ -23,7 +24,8 @@ def main(config: FunctionConfig) -> None:
         try_delete(client, config.external_id)
         return
 
-    # Zip files, upload to Files and create CogFunc:
+    # Run checks, then zip together and upload the code files, then create Function:
+    run_checks(config)
     function = upload_and_create(client, config)
     logger.info(f"Successfully created and deployed function {config.external_id} with id {function.id}")
     deploy_schedule(client, function, config)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,14 @@
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Union
+
+
+@contextmanager
+def temporary_chdir(path: Union[str, Path]):
+    old_path = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old_path)


### PR DESCRIPTION
## Changes
1. @pavelzubarev I was unable to find a working distroless container image running python 3.8.... so I added one that is probably "too large" for what is necessary? Do you have some input here?
2. Added humanize for some nicely formatted strings. It is maximally lightweight (it has no dependencies).
3. Added `--without-hashes` as backports might crash our action. Specified versions should be more than enough (imo).
2. The rest of the code is an AST check for handle function args, allowing us to run verification without actually installing & loading modules.