### PR TITLE
log warning for different cdf projects

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -69,7 +69,7 @@ class TenantConfig(BaseModel):
         deploy_project = cls._verify_credentials("deployment", values)
         runtime_project = cls._verify_credentials("runtime", values)
         if deploy_project != runtime_project:
-            raise ValueError(
+            logger.warning(
                 "The deployment- and runtime credentials are for separate projects, "
                 f"deployment: {deploy_project}, runtime: {runtime_project}"
             )


### PR DESCRIPTION
Replace raising an error with logging a warning

It is possible to deploy a function to another cdf project that has a runtime key to a different one.
This is used in bestday.